### PR TITLE
add option to configure permissions for each command separately

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -47,6 +47,10 @@
 ###############################
 
 # invunload.use:        Allows to use the commands /unload, /dump, /unloadinfo, /blacklist
+# invunload.unload:     Allows to use the command /unload
+# invunload.dump:       Allows to use the command /dump
+# invunload.unloadinfo: Allows to use the command /unloadinfo
+# invunload.blacklist:  Allows to use the command /blacklist
 # invunload.reload:     Allows to reload the config using /unload reload
 # invunload.search:     Allows to use the command /searchitem
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -13,19 +13,19 @@ commands:
     usage: |
             /<command> [radius] -- Unloads inventory in nearby matching chests
             /<command> hotbar -- Toggles whether /<command> affects your hotbar
-    permission: invunload.use
+    permission: invunload.unload
     aliases: [store,ul,invunload,unloadinv]
   dump:
     description: Unloads inventory in nearby matching chests and dumps the rest into the nearest chests
     usage: |
             /<command> [radius] -- Unloads inventory in nearby matching chests and dumps the rest into the nearest chests
             /<command> hotbar -- Toggles whether /<command> affects your hotbar
-    permission: invunload.use
+    permission: invunload.dump
     aliases: [invdump,dumpinv]
   unloadinfo:
     description: Shows into which chests your last /unload or /dump went into
     usage: /<command> [duration]
-    permission: invunload.use
+    permission: invunload.unloadinfo
     aliases: [dumpinfo,uli]
   searchitem:
     description: Searches for items in nearby chests
@@ -49,10 +49,23 @@ commands:
             /<command> remove hotbar -- Removes all items from your hotbar from your blacklist
             /<command> remove <items...> -- Remove items from your blacklist
             /<command> reset -- Removes all items from your blacklist
-    permission: invunload.use
+    permission: invunload.blacklist
 permissions:
+  invunload.unload:
+    description: Allows usage of the /unload command
+  invunload.dump:
+    description: Allows usage of the /dump command
+  invunload.unloadinfo:
+    description: Allows usage of the /unloadinfo command
+  invunload.blacklist:
+    description: Allows usage of the /blacklist command
   invunload.use:
     description: Allows usage of command /unload, /dump, /unloadinfo and /blacklist
+    children:
+      invunload.unload: true
+      invunload.dump: true
+      invunload.unloadinfo: true
+      invunload.blacklist: true
   invunload.search:
     description: Allows usage of the /searchitem command
   invunload.reload:


### PR DESCRIPTION
Adds separate permissions per each command.
Added permissions are declared as children of the `invunload.use` permission, so by default everything works the same, but there's now an option to configure permissions for each command separately instead of granting `invunload.use`.
New permissions:
- `invunload.unload` - allows to use the /unload command
- `invunload.dump`  - allows to use the /dump command
- `invunload.unloadinfo` - allows to use the /unloadinfo command
- `invunload.blacklist` - allows to use the /blacklist command

Resolves first point from https://github.com/JEFF-Media-GbR/InvUnload/issues/58.